### PR TITLE
🔨 accounts 모델 작성(#32)

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,24 +1,49 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from .models import User
+from .models import *
 from .forms import CustomUserChangeForm, CustomAdminUserCreationForm
 
 class CustomUserAdmin(UserAdmin):
-    fieldsets = (
-        (None, {"fields": ("email","password",)}),
-        ("Permissions", {"fields": ("is_active","is_staff","is_superuser","groups","user_permissions",)}),
-        ("Important dates", {"fields": ("last_login","date_joined",)}),
-    )
-    add_fieldsets = (
-        (None, {
-            "classes": ("wide",),
-            "fields": ("email","usable_password","password1","password2"),
-        }),
-    )
     form = CustomUserChangeForm
     add_form = CustomAdminUserCreationForm
+    
     list_display = ("email","is_staff",)
     search_fields = ("email",)
     ordering = ("email",)
 
+    fieldsets = (
+        (None, {"fields": ("email", "password")}),
+        ("Personal info", {
+            "fields": ("name", "birth", "sex", "profile_image", "is_marketing_allowed")
+        }),
+        ("Permissions", {
+            "fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")
+        }),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+
+    add_fieldsets = (
+        (None, {
+            "classes": (
+                "wide",
+            ),
+            "fields": (
+                "email",
+                # 비밀번호 생성 관련 (usable_password는 네 커스텀 폼 기준으로 유지)
+                "usable_password", "password1", "password2",
+
+                # 👇 추가화면에서도 필수 커스텀 필드 입력받도록
+                "name", "birth", "sex", "profile_image", "is_marketing_allowed",
+
+                # 권한(선택)
+                "is_active", "is_staff", "is_superuser", "groups", "user_permissions",
+            ),
+        }),
+    )
+
 admin.site.register(User, CustomUserAdmin)
+admin.site.register(Proposer)
+admin.site.register(Founder)
+admin.site.register(LocationHistory)
+admin.site.register(ProposerLevel)
+admin.site.register(PushSubscription)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,21 +1,29 @@
 from string import ascii_lowercase, digits
-from django.contrib.auth.models import AbstractUser
-from django.db import models
-from django_nanoid.models import NANOIDField
-from .managers import UserManager
 
+from django.conf import settings
+from django.contrib.auth.models import AbstractUser
+from django.core.validators import MinValueValidator, MaxValueValidator
+from django.db import models
+from django.utils import timezone
+from django_nanoid.models import NANOIDField
+from django.contrib.postgres.fields import ArrayField
+
+from .managers import UserManager
+from utils.choices import *
+
+# password, last_login, is_superuser, groups, user_permissions → AbstractUser에서 자동으로 제공.
 class User(AbstractUser):
     # AbstractUser 모델 오버라이딩
     username = None
     first_name = None
     last_name = None
+
     email = models.EmailField(
         unique=True,
-        error_messages={'unique': '이미 존재하는 이메일입니다.',},
+        error_messages={
+            'unique': '이미 존재하는 이메일입니다.',
+        },
     )
-    objects = UserManager()
-    USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = []
 
     # 커스텀 필드
     id = NANOIDField(
@@ -23,9 +31,204 @@ class User(AbstractUser):
         verbose_name='ID',
         editable=False,
         secure_generated=True,
-        alphabetically=ascii_lowercase+digits,
+        alphabetically=ascii_lowercase + digits,
         size=21,
     )
 
+    # 권한/상태
+    is_staff = models.BooleanField(
+        default=False,
+    )
+    is_active = models.BooleanField(
+        default=True,
+    )
+    date_joined = models.DateTimeField(
+        default=timezone.now,
+    )
+
+    is_marketing_allowed = models.BooleanField(
+        default=False
+    )  # 마케팅 및 메시지 수신 동의
+    name = models.CharField(
+        max_length=10,
+    )  # 이름(실명)
+
+    birth = models.CharField(
+        max_length=6,
+    )  # 생년월일 (YYMMDD 등 고정 6자리 표기)
+
+    sex = models.CharField(
+        max_length=5,
+        choices=SexChoices.choices,
+    )  # 성별
+
+    profile_image = models.ImageField(
+        upload_to='user',
+        null=True,
+        blank=True,
+    )
+
+    objects = UserManager()
+    
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = []
+
     def __str__(self):
         return self.email
+
+
+class Proposer(models.Model):
+    id = NANOIDField(
+        primary_key=True,
+        size=21,  
+        unique=True,
+        editable=False,
+        secure_generated=True,
+        alphabetically=ascii_lowercase + digits,
+    )
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+    )
+
+    industry = ArrayField(
+        base_field=models.CharField(
+            max_length=24,
+            choices=IndustryChoices.choices,
+        ),
+        size=3,
+    )
+
+class Founder(models.Model):
+    id = NANOIDField(
+        primary_key=True,
+        size=21,  
+        unique=True,
+        editable=False,
+        secure_generated=True,
+        alphabetically=ascii_lowercase + digits,
+    )
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+    )
+
+    industry = ArrayField(
+        base_field=models.CharField(
+            max_length=24,
+            choices=IndustryChoices.choices,
+        ),
+        size=3,
+    )
+    address = models.JSONField()   # { sido, sigungu, eupmyundong }
+    target = ArrayField(
+        base_field=models.CharField(
+            max_length=8,
+            choices=FounderTargetChoices.choices,
+        ),
+        size=2,
+    )
+    business_hours = models.JSONField()  # { start, end }
+
+class LocationHistory(models.Model):
+    id = models.BigAutoField(
+        primary_key=True,
+    )
+
+    user = models.ForeignKey(
+        "Proposer",
+        on_delete=models.CASCADE,
+    )
+
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+    )
+
+    address = models.JSONField()  # { sido, sigungu, eupmyundong }
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    'user', 
+                    'created_at'
+                    ],
+                name='unique_user_created_at',
+            )   
+       ]
+
+
+class ProposerLevel(models.Model):
+    id = models.BigAutoField(
+        primary_key=True,
+    )
+
+    user = models.ForeignKey(
+        "Proposer",
+        on_delete=models.CASCADE,
+    )
+
+    address = models.JSONField()  # { sido, sigungu, eupmyundong }
+
+    level = models.PositiveSmallIntegerField(
+        validators=[
+            MinValueValidator(1),
+            MaxValueValidator(3),
+        ],
+    )
+
+
+class PushSubscription(models.Model):
+    id = models.BigAutoField(
+        primary_key=True,
+    )
+
+    user = models.ForeignKey(
+        "Proposer",
+        on_delete=models.CASCADE,
+    )
+
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+    )
+
+    updated_at = models.DateTimeField(
+        auto_now=True,
+    )
+
+    endpoint = models.URLField(
+        max_length=500,
+    )
+
+    p256dh_key = models.CharField(
+        max_length=100,
+    )
+
+    auth_key = models.CharField(
+        max_length=50,
+    )
+
+    is_main = models.BooleanField()
+
+    is_active = models.BooleanField(
+        default=True,
+    )
+
+    last_success = models.DateTimeField(
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    'user', 
+                    'endpoint'
+                ],
+                name='unique_user_endpoint',
+            )
+       ]
+

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -4,8 +4,19 @@ from .models import User
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id','email','password',)
-        extra_kwargs = {'password': {'write_only': True}}
+        fields = (
+            'id',
+            'email',
+            'password',
+            'is_marketing_allowed',
+            'name',
+            'birth',
+            'sex',
+            'profile_image',
+        )
+        extra_kwargs = {
+            'password': {'write_only': True}
+        }
 
     def create(self, validated_data:dict):
         password = validated_data.pop('password')

--- a/pays/models.py
+++ b/pays/models.py
@@ -28,11 +28,11 @@ class Payment(models.Model):
     #     on_delete=models.PROTECT,
     #     related_name='payments',
     # )
-    # user = models.ForeignKey(
-    #     settings.AUTH_USER_MODEL,
-    #     on_delete=models.PROTECT,
-    #     related_name='payments',
-    # )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name='payments',
+    )
 
     version = models.CharField(
         max_length=10,


### PR DESCRIPTION
## 🔎 What is this PR?
accounts 도메인 관련 모델을 작성했습니다.
User, Proposer, Founder, LocationHistory, ProposerLevel, PushSubscription 객체를 작성했습니다.

## ✨ Changes

(1) User profile_image에 upload_to='user' 를 추가했습니다. 이는 이미지 경로를 설정해줍니다. 
 - Django가 업로드된 파일을 저장할 디렉토리를 지정하는 옵션으로, 사용자가 이미지를 업로드하면 Django는 MEDIA_ROOT/user/ 폴더 안에 저장되어서 폴더 구조상 user 관련 파일은 user 폴더(/media/user/프로필사진.png)에 모으는 게 가능해집니다. (ERD 반영 완료)
```
profile_image = models.ImageField(
        upload_to='user',
        null=True,
        blank=True,
    )
```
(2) User객체에서 # password, last_login, is_superuser, groups, user_permissions → AbstractUser에서 자동으로 제공하므로 생략했습니다. 

(3) User 객체의 is_marketing_allowed가 Not Null이라 default를 지정하지 않았을 때 오류가 나서 `Defulat = False`로 지정해주었습니다. (ERD 반영 완료)


## 📷 Result
- 스크린샷, 시연 영상 등

AbstractUser 기반 모델은 기본 라벨이 i18n 번역을 타서 admin 페이지에서 사용자(들)로 보인다고 합니다.
<img width="1378" height="1020" alt="스크린샷 2025-08-18 오전 2 46 26" src="https://github.com/user-attachments/assets/1a7e8ec9-7e79-45b8-af95-61550c0309de" />

## 💬 To. Reviewer
- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
