### PR TITLE
validate_path_choices 데코레이터 추가

### DIFF
--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -72,3 +72,29 @@ def require_query_params(*required_query_params:str):
             return view_func(request, *args, **kwargs)
         return wrapper
     return decorator
+
+def validate_path_choices(**path_variables):
+    """
+    Examples:
+        validate_path_choices(profile=('proposer', 'founder'))
+    """
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            errors = dict()
+
+            for var_name, choices in path_variables.items():
+                if var_name not in kwargs:
+                    errors[var_name] = "This path variable is required."
+                elif kwargs[var_name] not in choices:
+                    errors[var_name] = f"Ensure this value has one of these: {', '.join(str(choice) for choice in choices)}"
+
+            if errors:
+                return Response(
+                    errors,
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            return view_func(request, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -4,9 +4,9 @@ from rest_framework import status
 from rest_framework.response import Response
 
 def example(func):
-    '''
+    """
     예시 코드입니다.
-    '''
+    """
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # 여기에 데코레이터 코드를 작성하세요.

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -56,16 +56,15 @@ def require_query_params(*required_query_params:str):
     def decorator(view_func):
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
-            missing_params = []
+            errors = dict()
 
             for param in required_query_params:
                 if not request.query_params.get(param):
-                    missing_params.append(param)
+                    errors[param] = "This query parameter is required."
 
-            if missing_params:
-                missing_str = ', '.join(missing_params)
+            if errors:
                 return Response(
-                    {"detail":f"Required query parameters missing: {missing_str}"},
+                    errors,
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ Changes
- validate_path_choices 데코레이터를 추가했습니다.
   Path Variable이 튜플로 넘긴 값 중 하나와 일치하는지 검증합니다.
   다음과 같이 사용할 수 있습니다.
   ```python
   validate_path_choices(profile=('proposer', 'founder'))
   ```
- require_query_params 데코레이터의 응답 형식을 일반적인 Django 에러 응답 형식과 통일했습니다.

## 📷 Result

## 💬 To. Reviewer
